### PR TITLE
Feature/select language

### DIFF
--- a/docs/theme/_templates/globaltoc.html
+++ b/docs/theme/_templates/globaltoc.html
@@ -9,6 +9,12 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if builder != "singlehtml" %}
+<div class="languages" >
+    <select id="language" name="languages">
+        <option value="en">English</option>
+        <option value="ja">Japanese</option>
+    </select>
+</div>
 <div id="searchbox" role="search">
     <div class="searchformwrapper">
     <form class="search-form" action="{{ pathto('search') }}" method="get">

--- a/docs/theme/_templates/layout.html
+++ b/docs/theme/_templates/layout.html
@@ -75,4 +75,16 @@
           };
        </script>
         <script async src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
+         <script>
+            var el = document.getElementById('language');
+            el.addEventListener('change', function(evt){
+                var language = evt.target.options[el.selectedIndex].value;
+                if (language === 'ja') {
+                    window.location.href = '/locale/ja';
+                }
+                if (language === 'en') {
+                    window.location.href = '/';
+                }
+            });
+        </script>
 {%- endblock %}

--- a/docs/theme/static/css/theme.css
+++ b/docs/theme/static/css/theme.css
@@ -445,6 +445,10 @@ cursor: pointer;
     padding-left: 18px !important;
 }
 
+.languages {
+    margin: 0 0 31px 31px;
+}
+
 /* Search bar Styles */
 .search-form {
     display: flex;


### PR DESCRIPTION
### Summary
Added a selection combo to choose `english` or `japanese` language:

![image](https://user-images.githubusercontent.com/650752/59659358-564d0e80-91a6-11e9-9e49-323769003707.png)
![image](https://user-images.githubusercontent.com/650752/59659360-5816d200-91a6-11e9-8bc9-5e78ec638cda.png)

The JavaScript logic is listening on changes in select element. When the user select a new one you need to put the final URL where the translations goes.

```
if (language === 'ja') {
    window.location.href = '/locale/ja';
}
if (language === 'en') {
    window.location.href = '/';
}
```


